### PR TITLE
fixes compatibility issue with graphepp 0.5

### DIFF
--- a/src/noisy_graph_states/libs/graph.py
+++ b/src/noisy_graph_states/libs/graph.py
@@ -92,7 +92,7 @@ def disconnect_vertex(graph, index):
     Graph
         The updated graph.
     """
-    adj = graph.adj
+    adj = np.copy(graph.adj)
     adj[:, index] = np.zeros_like(adj[:, index])
     adj[index, :] = np.zeros_like(adj[index, :])
     return graph_from_adj_matrix(adj)


### PR DESCRIPTION
graphepp 0.5 provides the same read-only adjacency matrix instead of a new copy every time it is called. This fixes our writing to the read-only matrix in the `disconnect_vertex` function.