### PR TITLE
0.3.1 release

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "noisy_graph_states"
-copyright = "2023, Julius Wallnöfer"
+copyright = "2023, Julius Wallnöfer; 2024, Julius Wallnöfer and Maria Flors Mor-Ruiz"
 author = "Julius Wallnöfer"
 
 # -- General configuration ---------------------------------------------------

--- a/src/noisy_graph_states/libs/graph.py
+++ b/src/noisy_graph_states/libs/graph.py
@@ -92,7 +92,7 @@ def disconnect_vertex(graph, index):
     Graph
         The updated graph.
     """
-    adj = graph.adj
+    adj = np.copy(graph.adj)
     adj[:, index] = np.zeros_like(adj[:, index])
     adj[index, :] = np.zeros_like(adj[index, :])
     return graph_from_adj_matrix(adj)

--- a/src/noisy_graph_states/noisy_graph_states.py
+++ b/src/noisy_graph_states/noisy_graph_states.py
@@ -956,11 +956,11 @@ def reduce_maps(state, target_indices):
     for map in maps:
         reduced_noises = []
         for noise in map.noises:
-            noise = list(noise)
-            for index in noise:
+            new_noise = list(noise)
+            for index in noise:  # iterate over immutable original noise
                 if index not in target_indices:
-                    noise.remove(index)
-            reduced_noises += [tuple(noise)]
+                    new_noise.remove(index)
+            reduced_noises += [tuple(new_noise)]
         reduced_maps += [Map(map.weights, reduced_noises)]
     return reduced_maps
 

--- a/tests/nsf_tool_test/strategy_test.py
+++ b/tests/nsf_tool_test/strategy_test.py
@@ -83,7 +83,7 @@ def test_speedup():
     output_state = strategy(state)
     second_time = time() - start_time
     # this should assert it being noticeably faster without having too narrow requirements
-    assert second_time < (first_time / 2)
+    assert second_time < (first_time * 3 / 4)
 
     # now with time dependent noise
     def error_parameter_from_time_interval(time_interval, dephasing_time):
@@ -114,7 +114,7 @@ def test_speedup():
     output_state = strategy(state)
     third_time = time() - start_time
     # this should assert it being noticeably faster without having too narrow requirements
-    assert third_time < (first_time / 2)
+    assert third_time < (first_time * 3 / 4)
 
 
 def test_populate_cache():
@@ -138,7 +138,7 @@ def test_populate_cache():
     output_state = strategy(state)
     second_time = time() - start_time
     # this should assert it being noticeably faster without having too narrow requirements
-    assert second_time < (first_time / 2)
+    assert second_time < (first_time * 3 / 4)
 
     # now with time dependent noise
     def error_parameter_from_time_interval(time_interval, dephasing_time):
@@ -169,4 +169,4 @@ def test_populate_cache():
     output_state = strategy(state)
     third_time = time() - start_time
     # this should assert it being noticeably faster without having too narrow requirements
-    assert third_time < (first_time / 2)
+    assert third_time < (first_time * 3 / 4)


### PR DESCRIPTION
Bug fixes
* Fixes `reduce_map` not checking some of the noises correctly on larger states.
* Fixes compatibility issue with graphepp 0.5  (graphepp 0.4 is still the recommended version)

Notice:
The graphepp dependency will be removed in a future version and graphs will be described by networkx graphs instead