### PR TITLE
Added support to custom b0 nodes in sequences. Improved graph equality check.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# VsCode
+.vscode/
+
 # IPython
 profile_default/
 ipython_config.py

--- a/src/noisy_graph_states/libs/graph.py
+++ b/src/noisy_graph_states/libs/graph.py
@@ -224,6 +224,24 @@ def neighbourhood(graph, index):
     return tuple(graph[index])
 
 
+def check_equality(graph1, graph2):
+    """Check if two graphs are equal, i.e., they have the same edges, vertices and labels.
+
+    Parameters
+    ----------
+    graph1 : nx.Graph
+        The first graph.
+    graph2 : nx.Graph
+        The second graph.
+
+    Returns
+    -------
+    bool
+        True if the graphs are equal, False otherwise.
+
+    """
+    return nx.utils.graphs_equal(graph1, graph2)
+
 def update_graph_cnot(graph, source, target):
     """Returns the graph state after a CNOT between source and target.
 

--- a/src/noisy_graph_states/libs/graph.py
+++ b/src/noisy_graph_states/libs/graph.py
@@ -242,6 +242,7 @@ def check_equality(graph1, graph2):
     """
     return nx.utils.graphs_equal(graph1, graph2)
 
+
 def update_graph_cnot(graph, source, target):
     """Returns the graph state after a CNOT between source and target.
 

--- a/src/noisy_graph_states/noisy_graph_states.py
+++ b/src/noisy_graph_states/noisy_graph_states.py
@@ -208,7 +208,7 @@ class State(object):
         """
         if not isinstance(other, State):
             return NotImplemented
-        return nx.utils.graphs_equal(self.graph, other.graph) and compile_maps(
+        return gt.check_equality(self.graph, other.graph) and compile_maps(
             *self.maps
         ) == compile_maps(*other.maps)
 
@@ -326,7 +326,7 @@ class Strategy(object):
         """
         if not isinstance(other, State):
             raise TypeError("Strategy can only be applied to State objects.")
-        if not other.graph == self.graph:
+        if not gt.check_equality(self.graph, other.graph):
             raise ValueError(
                 f"State Graph {other.graph} is not compatible with Strategy Graph {self.graph}."
             )

--- a/src/noisy_graph_states/tools/patterns.py
+++ b/src/noisy_graph_states/tools/patterns.py
@@ -89,7 +89,7 @@ def sequence_to_pattern(sequence: list, graph: nx.Graph):
     return pattern
 
 
-def pattern_to_sequence(pattern: list, graph: nx.Graph):
+def pattern_to_sequence(pattern: list, graph: nx.Graph, support_nodes: list = None):
     """Find a sequence of graph measurements corresponding to a measurement pattern.
 
     Since multiple sequences can lead to the same pattern, this
@@ -111,6 +111,9 @@ def pattern_to_sequence(pattern: list, graph: nx.Graph):
         length must match `len(graph)`
     graph : nx.Graph
         The start graph to which the measurements are applied.
+    support_nodes : list[int] or None
+        A list of indices of support nodes for x measurements.
+        If None, the first neighbour of the qubit is used as support node.
 
     Returns
     -------
@@ -121,11 +124,11 @@ def pattern_to_sequence(pattern: list, graph: nx.Graph):
     assert len(pattern) == len(graph)
     matchings = defaultdict(_default_projector_matching)
     sequence = []
+    current_meas = 0
     for qubit_index, proj in enumerate(pattern):
         if proj == ".":
             continue
         effective_instruction = matchings[qubit_index][proj]
-        sequence.append((effective_instruction, qubit_index))
         if effective_instruction == "z":
             # no change in projector matchings required
             graph = gt.measure_z(graph=graph, index=qubit_index)
@@ -141,18 +144,23 @@ def pattern_to_sequence(pattern: list, graph: nx.Graph):
             graph = gt.measure_y(graph=graph, index=qubit_index)
         elif effective_instruction == "x":
             neighbours = gt.neighbourhood(graph=graph, index=qubit_index)
-            try:
-                b0 = neighbours[0]
-            except IndexError:
-                b0 = None
+            if support_nodes is None:
+                try:
+                    b0 = neighbours[0]
+                except IndexError:
+                    b0 = None
+            else:
+                b0 = support_nodes[current_meas]
             if b0 is not None:
-                match = matchings[b0]
-                for k, v in match.items():
-                    if v == "x":
-                        match[k] = "z"
-                    elif v == "z":
-                        match[k] = "x"
+                    match = matchings[b0]
+                    for k, v in match.items():
+                        if v == "x":
+                            match[k] = "z"
+                        elif v == "z":
+                            match[k] = "x"
             graph = gt.measure_x(graph=graph, index=qubit_index, b0=b0)
+        sequence.append((effective_instruction, qubit_index, b0 if effective_instruction == "x" else None))
+        current_meas += 1
     return tuple(sequence)
 
 

--- a/src/noisy_graph_states/tools/patterns.py
+++ b/src/noisy_graph_states/tools/patterns.py
@@ -80,11 +80,11 @@ def sequence_to_pattern(sequence: list, graph: nx.Graph):
                     b0 = neighbours[0]
                 except IndexError:
                     b0 = None
-                if b0 is not None:
-                    match = matchings[b0]
-                    tmp = match["x"]
-                    match["x"] = match["z"]
-                    match["z"] = tmp
+            if b0 is not None:
+                match = matchings[b0]
+                tmp = match["x"]
+                match["x"] = match["z"]
+                match["z"] = tmp
             graph = gt.measure_x(graph=graph, index=qubit_index, b0=b0)
     return pattern
 
@@ -124,6 +124,7 @@ def pattern_to_sequence(pattern: list, graph: nx.Graph, support_nodes: list = No
     assert len(pattern) == len(graph)
     matchings = defaultdict(_default_projector_matching)
     sequence = []
+    b0 = None
     current_meas = 0
     for qubit_index, proj in enumerate(pattern):
         if proj == ".":
@@ -143,23 +144,23 @@ def pattern_to_sequence(pattern: list, graph: nx.Graph, support_nodes: list = No
                         match[k] = "x"
             graph = gt.measure_y(graph=graph, index=qubit_index)
         elif effective_instruction == "x":
-            neighbours = gt.neighbourhood(graph=graph, index=qubit_index)
-            if support_nodes is None:
+            if support_nodes is not None:
+                b0 = support_nodes[current_meas]
+            else:
                 try:
+                    neighbours = gt.neighbourhood(graph=graph, index=qubit_index)
                     b0 = neighbours[0]
                 except IndexError:
                     b0 = None
-            else:
-                b0 = support_nodes[current_meas]
             if b0 is not None:
-                    match = matchings[b0]
-                    for k, v in match.items():
-                        if v == "x":
-                            match[k] = "z"
-                        elif v == "z":
-                            match[k] = "x"
+                match = matchings[b0]
+                for k, v in match.items():
+                    if v == "x":
+                        match[k] = "z"
+                    elif v == "z":
+                        match[k] = "x"
             graph = gt.measure_x(graph=graph, index=qubit_index, b0=b0)
-        sequence.append((effective_instruction, qubit_index, b0 if effective_instruction == "x" else None))
+        sequence.append((effective_instruction, qubit_index, b0))
         current_meas += 1
     return tuple(sequence)
 
@@ -207,7 +208,6 @@ def pattern_to_all_sequences(pattern: list, graph: nx.Graph):
             if proj == ".":
                 continue
             effective_instruction = matchings[qubit_index][proj]
-            sequence.append((effective_instruction, qubit_index))
             if effective_instruction == "z":
                 # no change in projector matchings required
                 graph = gt.measure_z(graph=graph, index=qubit_index)
@@ -235,5 +235,6 @@ def pattern_to_all_sequences(pattern: list, graph: nx.Graph):
                         elif v == "z":
                             match[k] = "x"
                 graph = gt.measure_x(graph=graph, index=qubit_index, b0=b0)
+            sequence.append((effective_instruction, qubit_index, None))
         sequences.append(sequence)
     return sequences

--- a/src/noisy_graph_states/tools/patterns.py
+++ b/src/noisy_graph_states/tools/patterns.py
@@ -235,6 +235,6 @@ def pattern_to_all_sequences(pattern: list, graph: nx.Graph):
                         elif v == "z":
                             match[k] = "x"
                 graph = gt.measure_x(graph=graph, index=qubit_index, b0=b0)
-            sequence.append((effective_instruction, qubit_index, None))
+            sequence.append((effective_instruction, qubit_index))
         sequences.append(sequence)
     return sequences

--- a/tests/graph_tool_test.py
+++ b/tests/graph_tool_test.py
@@ -30,6 +30,14 @@ def test_neighbourhood():
         assert neighbourhood == target_neighbourhood
 
 
+def test_check_equality():
+    graph1 = nx.Graph([(0, 1), (1, 2)])
+    graph2 = nx.Graph([(0, 1), (1, 2)])
+    graph3 = nx.Graph([(0, 1), (1, 3)])
+    assert gt.check_equality(graph1, graph2)
+    assert not gt.check_equality(graph1, graph3)
+
+
 def test_update_graph_cnot():
     start_graph = nx.Graph([(0, 1), (1, 2), (3, 4)])
     target_graph = nx.Graph([(0, 1), (1, 2), (3, 4), (1, 4)])

--- a/tests/pattern_sequence_conversion_test.py
+++ b/tests/pattern_sequence_conversion_test.py
@@ -96,12 +96,15 @@ def test_pattern_all_reversible_general():
 
 
 def test_pattern_custom_b0():
-    """Test that the b0 parameter is correctly applied in the pattern_to_sequence function."""
-    start_graph = nx.Graph([(0, 1), (1, 2), (2, 3), (3, 4)])
-    input_pattern = [".", "x", ".", "x", "."]
-    support_nodes = [2, 4]  
-    sequences = pattern_to_sequence(
-        pattern=input_pattern, graph=start_graph, support_nodes=support_nodes
-    )
-    assert sequences[0][0] == "x"  and sequences[0][1] == 1 and sequences[0][2] == 2  # First measurement should be x on qubit 1 with b0=2
-    assert sequences[1][0] == "x"  and sequences[1][1] == 3 and sequences[1][2] == 4  # Second measurement should be x on qubit 3 with b0=4
+    """Test that the b0 parameter is correctly applied in the pattern_to_sequence function for a linear graph."""
+    for N in range(2, 10):
+        start_graph = nx.Graph([(i, i + 1) for i in range(N - 1)])
+        input_pattern = ["x" if i % 2 != 0 else "." for i in range(N)]
+        support_nodes = [i for i in range(N-1) if i % 2 == 0]
+        sequences = pattern_to_sequence(
+            pattern=input_pattern, graph=start_graph, support_nodes=support_nodes
+        )
+        for idx, support_node in enumerate(support_nodes):
+            assert sequences[idx][0] == "x"
+            assert sequences[idx][1] == support_node+1
+            assert sequences[idx][2] == support_node

--- a/tests/pattern_sequence_conversion_test.py
+++ b/tests/pattern_sequence_conversion_test.py
@@ -103,6 +103,5 @@ def test_pattern_custom_b0():
     sequences = pattern_to_sequence(
         pattern=input_pattern, graph=start_graph, support_nodes=support_nodes
     )
-    
     assert sequences[0][0] == "x"  and sequences[0][1] == 1 and sequences[0][2] == 2  # First measurement should be x on qubit 1 with b0=2
     assert sequences[1][0] == "x"  and sequences[1][1] == 3 and sequences[1][2] == 4  # Second measurement should be x on qubit 3 with b0=4

--- a/tests/pattern_sequence_conversion_test.py
+++ b/tests/pattern_sequence_conversion_test.py
@@ -93,3 +93,16 @@ def test_pattern_all_reversible_general():
             for sequence in sequences:
                 output_pattern = sequence_to_pattern(sequence, graph=start_graph)
                 assert input_pattern == output_pattern
+
+
+def test_pattern_custom_b0():
+    """Test that the b0 parameter is correctly applied in the pattern_to_sequence function."""
+    start_graph = nx.Graph([(0, 1), (1, 2), (2, 3), (3, 4)])
+    input_pattern = [".", "x", ".", "x", "."]
+    support_nodes = [2, 4]  
+    sequences = pattern_to_sequence(
+        pattern=input_pattern, graph=start_graph, support_nodes=support_nodes
+    )
+    
+    assert sequences[0][0] == "x"  and sequences[0][1] == 1 and sequences[0][2] == 2  # First measurement should be x on qubit 1 with b0=2
+    assert sequences[1][0] == "x"  and sequences[1][1] == 3 and sequences[1][2] == 4  # Second measurement should be x on qubit 3 with b0=4

--- a/tests/pattern_sequence_conversion_test.py
+++ b/tests/pattern_sequence_conversion_test.py
@@ -3,6 +3,7 @@ from random import choices
 from itertools import permutations
 from collections import defaultdict
 import noisy_graph_states.libs.graph as gt
+import noisy_graph_states as ngs
 from noisy_graph_states.tools.patterns import sequence_to_pattern
 from noisy_graph_states.tools.patterns import pattern_to_sequence
 from noisy_graph_states.tools.patterns import pattern_to_all_sequences
@@ -100,11 +101,36 @@ def test_pattern_custom_b0():
     for N in range(2, 10):
         start_graph = nx.Graph([(i, i + 1) for i in range(N - 1)])
         input_pattern = ["x" if i % 2 != 0 else "." for i in range(N)]
-        support_nodes = [i for i in range(N-1) if i % 2 == 0]
+        support_nodes = [i for i in range(N - 1) if i % 2 == 0]
         sequences = pattern_to_sequence(
             pattern=input_pattern, graph=start_graph, support_nodes=support_nodes
         )
         for idx, support_node in enumerate(support_nodes):
             assert sequences[idx][0] == "x"
-            assert sequences[idx][1] == support_node+1
+            assert sequences[idx][1] == support_node + 1
             assert sequences[idx][2] == support_node
+
+
+def test_check_graph_equality_with_states():
+    """Test that the graph equality check works correctly."""
+    for N in range(2, 10):
+        graph1 = nx.Graph([(i, i + 1) for i in range(N - 1)])
+        graph2 = nx.Graph([(i, i + 1) for i in range(N - 1)])
+        pattern = ["x"] * N
+        # State corresponding to graph1
+        state1 = ngs.State(graph=graph1, maps=[])
+        sequence = pattern_to_sequence(pattern, graph1)
+        meas_strategy = ngs.Strategy(sequence=sequence, graph=graph1)
+        output_state1 = meas_strategy(state1)
+        # State corresponding to graph2
+        state2 = ngs.State(graph=graph2, maps=[])
+        sequence = pattern_to_sequence(pattern, graph2)
+        meas_strategy = ngs.Strategy(sequence=sequence, graph=graph2)
+        output_state2 = meas_strategy(state2)
+        assert output_state1.graph == output_state1.graph  # graphs are the same object
+        assert (
+            not output_state1.graph == output_state2.graph
+        )  # graphs are different objects
+        assert gt.check_equality(
+            output_state1.graph, output_state2.graph
+        )  # graphs are equal in structure


### PR DESCRIPTION

- Modified pattern_to_sequence in patterns.py function to support a list of custom b0 node to be embedded int the output sequence. Originally, only the first neighbour of each measured vertex was selected as b0 node.

- Modified graph.py to support graph equality check (topological, with fixed labels) and related fixed to noisy_graph_states.py

- Added related tests for the new functionalities.